### PR TITLE
Adding support for iOS 5.1

### DIFF
--- a/Sources/ReaderMainPagebar.m
+++ b/Sources/ReaderMainPagebar.m
@@ -186,7 +186,9 @@
 		pageNumberLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
 		pageNumberLabel.shadowColor = [UIColor blackColor];
 		pageNumberLabel.adjustsFontSizeToFitWidth = YES;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
 		pageNumberLabel.minimumScaleFactor = 0.75f;
+#endif
 
 		[pageNumberView addSubview:pageNumberLabel]; // Add label view
 

--- a/Sources/ReaderMainToolbar.m
+++ b/Sources/ReaderMainToolbar.m
@@ -216,7 +216,9 @@
 			titleLabel.backgroundColor = [UIColor clearColor];
 			titleLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
 			titleLabel.adjustsFontSizeToFitWidth = YES;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
 			titleLabel.minimumScaleFactor = 0.75f;
+#endif
 			titleLabel.text = (object.title.length > 0 ? object.title : [object.fileName stringByDeletingPathExtension]);
 
 			[self addSubview:titleLabel]; 

--- a/Sources/ThumbsMainToolbar.m
+++ b/Sources/ThumbsMainToolbar.m
@@ -124,7 +124,9 @@
 			titleLabel.backgroundColor = [UIColor clearColor];
 			titleLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
 			titleLabel.adjustsFontSizeToFitWidth = YES;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
 			titleLabel.minimumScaleFactor = 0.75f;
+#endif
 			titleLabel.text = title;
 
 			[self addSubview:titleLabel]; 


### PR DESCRIPTION
the current 2.7.1 version of reader calls UILabel.minimumScaleFactor which is a 6.0 and up api so adding if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000 around that call will allow
reader to work on iOS 5.1 devices again.
